### PR TITLE
Revert "Fix fetch header from a HTTPMessage"

### DIFF
--- a/pyamf/remoting/client/__init__.py
+++ b/pyamf/remoting/client/__init__.py
@@ -455,10 +455,10 @@ class RemotingService(object):
 
         http_message = fbh.info()
 
-        content_encoding = http_message.get('Content-Encoding')
-        content_length = http_message.get('Content-Length') or -1
-        content_type = http_message.get('Content-Type')
-        server = http_message.get('Server')
+        content_encoding = http_message.getheader('Content-Encoding')
+        content_length = http_message.getheader('Content-Length') or -1
+        content_type = http_message.getheader('Content-Type')
+        server = http_message.getheader('Server')
 
         if self.logger:
             self.logger.debug('Content-Type: %r', content_type)


### PR DESCRIPTION
Reverts StdCarrot/Py3AMF#1

This pull request couldn't pass test case.

```
======================================================================
ERROR: test_bad_response (pyamf.tests.remoting.test_client.GZipTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/yohan/IdeaProjects/Py3AMF/pyamf/tests/remoting/test_client.py", line 663, in test_bad_response
    self.assertRaises(IOError, self.gw._getResponse, None)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/unittest/case.py", line 727, in assertRaises
    return context.handle('assertRaises', args, kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/unittest/case.py", line 176, in handle
    callable_obj(*args, **kwargs)
  File "/Users/yohan/IdeaProjects/Py3AMF/pyamf/remoting/client/__init__.py", line 458, in _getResponse
    content_encoding = http_message.get('Content-Encoding')
AttributeError: 'MockHeaderCollection' object has no attribute 'get'

```