### PR TITLE
Fix fetch header from a HTTPMessage

### DIFF
--- a/pyamf/remoting/client/__init__.py
+++ b/pyamf/remoting/client/__init__.py
@@ -455,10 +455,10 @@ class RemotingService(object):
 
         http_message = fbh.info()
 
-        content_encoding = http_message.getheader('Content-Encoding')
-        content_length = http_message.getheader('Content-Length') or -1
-        content_type = http_message.getheader('Content-Type')
-        server = http_message.getheader('Server')
+        content_encoding = http_message.get('Content-Encoding')
+        content_length = http_message.get('Content-Length') or -1
+        content_type = http_message.get('Content-Type')
+        server = http_message.get('Server')
 
         if self.logger:
             self.logger.debug('Content-Type: %r', content_type)

--- a/pyamf/tests/remoting/test_client.py
+++ b/pyamf/tests/remoting/test_client.py
@@ -239,7 +239,7 @@ class MockHeaderCollection(object):
     def __init__(self, headers):
         self.headers = headers
 
-    def getheader(self, name):
+    def get(self, name):
         return self.headers.get(name, None)
 
     def __repr__(self):


### PR DESCRIPTION
Support python3 by switching getheader() to get() to fetch a header value from a http.client.HTTPMessage


