### PR TITLE
Support for python 3.6

### DIFF
--- a/pyamf/util/__init__.py
+++ b/pyamf/util/__init__.py
@@ -215,5 +215,5 @@ def get_module(mod_name):
 
 try:
     datetime.datetime.utcfromtimestamp(-31536000.0)
-except ValueError:
+except (ValueError, OSError):
     negative_timestamp_broken = True


### PR DESCRIPTION
Under Python 3.6 negative timestamp produce OSError instead of Value error. Fix it