### PR TITLE
Fix of StopIteration errors for Python 3.8 and fix of ByteArray __str__ and __bytes__ methods

### DIFF
--- a/pyamf/amf3.py
+++ b/pyamf/amf3.py
@@ -546,7 +546,7 @@ class ByteArray(util.BufferedByteStream, DataInput, DataOutput):
 
         buf = zlib.compress(buf)
         # FIXME nick: hacked
-        return buf[0] + b'\xda' + buf[2:]
+        return buf[:1] + b'\xda' + buf[2:]
 
     def __bytes__(self):
         buf = self.getvalue()
@@ -556,7 +556,7 @@ class ByteArray(util.BufferedByteStream, DataInput, DataOutput):
 
         buf = zlib.compress(buf)
         # FIXME nick: hacked
-        return buf[0] + b'\xda' + buf[2:]
+        return buf[:1] + b'\xda' + buf[2:]
 
     def compress(self):
         """

--- a/pyamf/remoting/__init__.py
+++ b/pyamf/remoting/__init__.py
@@ -176,16 +176,12 @@ class Envelope(object):
         for body in self.bodies:
             yield body[0], body[1]
 
-        raise StopIteration
-
     def __len__(self):
         return len(self.bodies)
 
     def iteritems(self):
         for body in self.bodies:
             yield body
-
-        raise StopIteration
 
     def keys(self):
         return [body[0] for body in self.bodies]


### PR DESCRIPTION
StopIteration errors are replaced by RuntimeError in Python 3.7+ 
See https://docs.python.org/3/whatsnew/3.7.html#changes-in-python-behavior and https://www.python.org/dev/peps/pep-0479/

Incorrect merge of int and bytes replaced by concatenation bytes and bytes in ByteArray __str__ and __bytes__ methods