### PR TITLE
Fix of the binary version of the PyAMF

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,3 +7,5 @@ include *.txt
 include *.md
 global-exclude *.swf
 global-exclude *.pyc
+include cpyamf/*.pyx
+include cpyamf/*.pxd

--- a/cpyamf/amf0.pyx
+++ b/cpyamf/amf0.pyx
@@ -229,7 +229,7 @@ cdef class Decoder(codec.Decoder):
         l = self.stream.read_ulong()
 
         self.stream.read(&b, l)
-        s = PyString_FromStringAndSize(b, <Py_ssize_t>l)
+        s = PyUnicode_FromStringAndSize(b, <Py_ssize_t>l)
 
         if bytes:
             return s

--- a/cpyamf/amf0.pyx
+++ b/cpyamf/amf0.pyx
@@ -386,6 +386,28 @@ cdef class Encoder(codec.Encoder):
 
         return 0
 
+    cdef int writeSet(self, object a) except -1:
+        cdef Py_ssize_t size = -1, i = -1
+
+        if self.writeReference(a) != -1:
+            return 0
+
+        self.context.addObject(a)
+
+        self.writeType(TYPE_ARRAY)
+        size = PySet_GET_SIZE(a)
+
+        self.stream.write_ulong(size)
+
+        set_iter = iter(a)
+        while True:
+            try:
+                self.writeElement(next(set_iter))
+            except StopIteration:
+                break
+
+        return 0
+
     cdef int writeInt(self, object a) except -1:
         self.writeType(TYPE_NUMBER)
 

--- a/cpyamf/amf0.pyx
+++ b/cpyamf/amf0.pyx
@@ -6,7 +6,6 @@ C-extension for L{pyamf.amf3} Python module in L{PyAMF<pyamf>}.
 
 :since: 0.6
 """
-
 from cpython cimport *
 from libc.stdlib cimport *
 from libc.string cimport *
@@ -20,24 +19,24 @@ import pyamf
 from pyamf import xml, util
 
 
-cdef char TYPE_NUMBER      = '\x00'
-cdef char TYPE_BOOL        = '\x01'
-cdef char TYPE_STRING      = '\x02'
-cdef char TYPE_OBJECT      = '\x03'
-cdef char TYPE_MOVIECLIP   = '\x04'
-cdef char TYPE_NULL        = '\x05'
-cdef char TYPE_UNDEFINED   = '\x06'
-cdef char TYPE_REFERENCE   = '\x07'
-cdef char TYPE_MIXEDARRAY  = '\x08'
-cdef char TYPE_OBJECTTERM  = '\x09'
-cdef char TYPE_ARRAY       = '\x0A'
-cdef char TYPE_DATE        = '\x0B'
-cdef char TYPE_LONGSTRING  = '\x0C'
-cdef char TYPE_UNSUPPORTED = '\x0D'
-cdef char TYPE_RECORDSET   = '\x0E'
-cdef char TYPE_XML         = '\x0F'
-cdef char TYPE_TYPEDOBJECT = '\x10'
-cdef char TYPE_AMF3        = '\x11'
+cdef char TYPE_NUMBER      = b'\x00'
+cdef char TYPE_BOOL        = b'\x01'
+cdef char TYPE_STRING      = b'\x02'
+cdef char TYPE_OBJECT      = b'\x03'
+cdef char TYPE_MOVIECLIP   = b'\x04'
+cdef char TYPE_NULL        = b'\x05'
+cdef char TYPE_UNDEFINED   = b'\x06'
+cdef char TYPE_REFERENCE   = b'\x07'
+cdef char TYPE_MIXEDARRAY  = b'\x08'
+cdef char TYPE_OBJECTTERM  = b'\x09'
+cdef char TYPE_ARRAY       = b'\x0A'
+cdef char TYPE_DATE        = b'\x0B'
+cdef char TYPE_LONGSTRING  = b'\x0C'
+cdef char TYPE_UNSUPPORTED = b'\x0D'
+cdef char TYPE_RECORDSET   = b'\x0E'
+cdef char TYPE_XML         = b'\x0F'
+cdef char TYPE_TYPEDOBJECT = b'\x10'
+cdef char TYPE_AMF3        = b'\x11'
 
 
 cdef object ASObject = pyamf.ASObject
@@ -329,9 +328,9 @@ cdef class Encoder(codec.Encoder):
         self.writeType(TYPE_BOOL)
 
         if b is True:
-            return self.writeType('\x01')
+            return self.writeType(b'\x01')
         else:
-            return self.writeType('\x00')
+            return self.writeType(b'\x00')
 
     cdef int writeUndefined(self, data) except -1:
         return self.writeType(TYPE_UNDEFINED)

--- a/cpyamf/amf0.pyx
+++ b/cpyamf/amf0.pyx
@@ -228,7 +228,7 @@ cdef class Decoder(codec.Decoder):
         l = self.stream.read_ulong()
 
         self.stream.read(&b, l)
-        s = PyUnicode_FromStringAndSize(b, <Py_ssize_t>l)
+        s = b[:l].decode()
 
         if bytes:
             return s

--- a/cpyamf/amf3.pyx
+++ b/cpyamf/amf3.pyx
@@ -508,7 +508,7 @@ cdef class Decoder(codec.Decoder):
         cdef object s
 
         self.stream.read(&buf, ref)
-        s = PyString_FromStringAndSize(buf, ref)
+        s = PyUnicode_FromStringAndSize(buf, ref)
 
         x = xml.fromstring(
             s,
@@ -540,7 +540,7 @@ cdef class Decoder(codec.Decoder):
         ref >>= 1
 
         self.stream.read(&buf, ref)
-        s = PyString_FromStringAndSize(buf, ref)
+        s = PyUnicode_FromStringAndSize(buf, ref)
 
         if zlib:
             if ref > 2 and buf[0] == '\x78' and buf[1] == '\x9c':

--- a/cpyamf/amf3.pyx
+++ b/cpyamf/amf3.pyx
@@ -25,22 +25,22 @@ except ImportError:
     zlib = None
 
 
-cdef char TYPE_UNDEFINED = '\x00'
-cdef char TYPE_NULL = '\x01'
-cdef char TYPE_BOOL_FALSE = '\x02'
-cdef char TYPE_BOOL_TRUE = '\x03'
-cdef char TYPE_INTEGER = '\x04'
-cdef char TYPE_NUMBER = '\x05'
-cdef char TYPE_STRING = '\x06'
-cdef char TYPE_XML = '\x07'
-cdef char TYPE_DATE = '\x08'
-cdef char TYPE_ARRAY = '\x09'
-cdef char TYPE_OBJECT = '\x0A'
-cdef char TYPE_XMLSTRING = '\x0B'
-cdef char TYPE_BYTEARRAY = '\x0C'
+cdef char TYPE_UNDEFINED = b'\x00'
+cdef char TYPE_NULL = b'\x01'
+cdef char TYPE_BOOL_FALSE = b'\x02'
+cdef char TYPE_BOOL_TRUE = b'\x03'
+cdef char TYPE_INTEGER = b'\x04'
+cdef char TYPE_NUMBER = b'\x05'
+cdef char TYPE_STRING = b'\x06'
+cdef char TYPE_XML = b'\x07'
+cdef char TYPE_DATE = b'\x08'
+cdef char TYPE_ARRAY = b'\x09'
+cdef char TYPE_OBJECT = b'\x0A'
+cdef char TYPE_XMLSTRING = b'\x0B'
+cdef char TYPE_BYTEARRAY = b'\x0C'
 
 cdef unsigned int REFERENCE_BIT = 0x01
-cdef char REF_CHAR = '\x01'
+cdef char REF_CHAR = b'\x01'
 
 #: The maximum that can be represented by an signed 29 bit integer.
 cdef long MAX_29B_INT = 0x0FFFFFFF
@@ -543,7 +543,7 @@ cdef class Decoder(codec.Decoder):
         s = PyUnicode_FromStringAndSize(buf, ref)
 
         if zlib:
-            if ref > 2 and buf[0] == '\x78' and buf[1] == '\x9c':
+            if ref > 2 and buf[0] == b'\x78' and buf[1] == b'\x9c':
                 try:
                     s = zlib.decompress(s)
                 except zlib.error:
@@ -718,7 +718,7 @@ cdef class Encoder(codec.Encoder):
 
         _encode_integer(self.stream, (ref << 1) | REFERENCE_BIT)
 
-        self.writeType('\x01')
+        self.writeType(b'\x01')
 
         for i from 0 <= i < ref:
             x = PyList_GET_ITEM(n, i)
@@ -742,7 +742,7 @@ cdef class Encoder(codec.Encoder):
         ref = PyTuple_GET_SIZE(n)
 
         _encode_integer(self.stream, (ref << 1) | REFERENCE_BIT)
-        self.writeType('\x01')
+        self.writeType(b'\x01')
 
         for i from 0 <= i < ref:
             x = PyTuple_GET_ITEM(n, i)

--- a/cpyamf/amf3.pyx
+++ b/cpyamf/amf3.pyx
@@ -508,7 +508,7 @@ cdef class Decoder(codec.Decoder):
         cdef object s
 
         self.stream.read(&buf, ref)
-        s = PyUnicode_FromStringAndSize(buf, ref)
+        s = buf[:ref].decode()
 
         x = xml.fromstring(
             s,
@@ -540,7 +540,7 @@ cdef class Decoder(codec.Decoder):
         ref >>= 1
 
         self.stream.read(&buf, ref)
-        s = PyUnicode_FromStringAndSize(buf, ref)
+        s = buf[:ref].decode()
 
         if zlib:
             if ref > 2 and buf[0] == b'\x78' and buf[1] == b'\x9c':

--- a/cpyamf/amf3.pyx
+++ b/cpyamf/amf3.pyx
@@ -636,7 +636,7 @@ cdef class Encoder(codec.Encoder):
             l = PyUnicode_GET_SIZE(u)
             is_unicode = 1
         elif PyString_Check(u):
-            l = PyString_GET_SIZE(u)
+            l = len(u)
         else:
             raise TypeError('Expected str or unicode')
 
@@ -654,7 +654,7 @@ cdef class Encoder(codec.Encoder):
 
         if is_unicode:
             u = self.context.getBytesForString(u)
-            l = PyString_GET_SIZE(u)
+            l = len(u)
 
         _encode_integer(self.stream, (l << 1) | REFERENCE_BIT)
 
@@ -967,7 +967,7 @@ cdef class Encoder(codec.Encoder):
         self.context.addObject(obj)
 
         buf = str(obj)
-        l = PyString_GET_SIZE(buf)
+        l = len(buf)
 
         _encode_integer(self.stream, (l << 1) | REFERENCE_BIT)
         self.stream.write(PyString_AS_STRING(buf), l)
@@ -991,7 +991,7 @@ cdef class Encoder(codec.Encoder):
         if not PyString_CheckExact(s):
             raise TypeError('Expected string from xml serialization')
 
-        i = PyString_GET_SIZE(s)
+        i = len(s)
 
         _encode_integer(self.stream, (i << 1) | REFERENCE_BIT)
         self.stream.write(PyString_AS_STRING(s), i)

--- a/cpyamf/codec.pxd
+++ b/cpyamf/codec.pxd
@@ -60,8 +60,8 @@ cdef class Context(object):
     cpdef Py_ssize_t getObjectReference(self, object obj) except -2
     cpdef Py_ssize_t addObject(self, object obj) except -1
 
-    cpdef unicode getStringForBytes(self, object s)
-    cpdef str getBytesForString(self, object u)
+    cpdef str getStringForBytes(self, object s)
+    cpdef bytes getBytesForString(self, object u)
 
 
 cdef class Codec(object):
@@ -117,6 +117,7 @@ cdef class Encoder(Codec):
     cdef int writeDate(self, object o) except -1
     cdef int writeXML(self, object o) except -1
     cpdef int writeList(self, object o, bint is_proxy=?) except -1
+    cdef int writeSet(self, object o) except -1
     cdef int writeTuple(self, object o) except -1
     cdef int writeSequence(self, object iterable) except -1
     cpdef int writeObject(self, object o, bint is_proxy=?) except -1

--- a/cpyamf/util.pyx
+++ b/cpyamf/util.pyx
@@ -56,7 +56,7 @@ cdef object empty_unicode = unicode('')
 
 
 @cython.profile(False)
-cdef int _memcpy_ensure_endian(void *src, void *dest, unsigned int size) nogil:
+cdef int _memcpy_ensure_endian(void *src, void *dest, unsigned int size):
     """
     """
     cdef unsigned char *buf = <unsigned char *>malloc(size)
@@ -117,7 +117,7 @@ cdef int build_platform_exceptional_floats() except -1:
 
 
 @cython.profile(False)
-cdef char get_native_endian() nogil:
+cdef char get_native_endian():
     """
     A quick hack to determine the system's endian-ness ...
 
@@ -133,7 +133,7 @@ cdef char get_native_endian() nogil:
 
 
 @cython.profile(False)
-cdef inline bint is_big_endian(char endian) nogil:
+cdef inline bint is_big_endian(char endian):
     """
     Returns a boolean value whether the supplied C{endian} is big.
     """
@@ -144,7 +144,7 @@ cdef inline bint is_big_endian(char endian) nogil:
 
 
 @cython.profile(False)
-cdef inline int is_native_endian(char endian) nogil:
+cdef inline int is_native_endian(char endian):
     if endian == ENDIAN_NATIVE:
         return 1
 
@@ -155,7 +155,7 @@ cdef inline int is_native_endian(char endian) nogil:
 
 
 @cython.profile(False)
-cdef inline int swap_bytes(unsigned char *buffer, Py_ssize_t size) nogil:
+cdef inline int swap_bytes(unsigned char *buffer, Py_ssize_t size):
     cdef unsigned char *buf = <unsigned char *>malloc(size)
 
     if buf == NULL:

--- a/cpyamf/util.pyx
+++ b/cpyamf/util.pyx
@@ -26,10 +26,10 @@ cdef extern from "Python.h":
 from pyamf import python
 
 # module constant declarations
-DEF ENDIAN_NETWORK = "!"
-DEF ENDIAN_NATIVE = "@"
-DEF ENDIAN_LITTLE = "<"
-DEF ENDIAN_BIG = ">"
+DEF ENDIAN_NETWORK = b"!"
+DEF ENDIAN_NATIVE = b"@"
+DEF ENDIAN_LITTLE = b"<"
+DEF ENDIAN_BIG = b">"
 
 DEF MAX_BUFFER_EXTENSION = 1 << 14
 
@@ -56,7 +56,7 @@ cdef object empty_unicode = unicode('')
 
 
 @cython.profile(False)
-cdef int _memcpy_ensure_endian(void *src, void *dest, unsigned int size):
+cdef int _memcpy_ensure_endian(void *src, void *dest, unsigned int size) nogil:
     """
     """
     cdef unsigned char *buf = <unsigned char *>malloc(size)
@@ -117,7 +117,7 @@ cdef int build_platform_exceptional_floats() except -1:
 
 
 @cython.profile(False)
-cdef char get_native_endian():
+cdef char get_native_endian() nogil:
     """
     A quick hack to determine the system's endian-ness ...
 
@@ -133,7 +133,7 @@ cdef char get_native_endian():
 
 
 @cython.profile(False)
-cdef inline bint is_big_endian(char endian):
+cdef inline bint is_big_endian(char endian) nogil:
     """
     Returns a boolean value whether the supplied C{endian} is big.
     """
@@ -144,7 +144,7 @@ cdef inline bint is_big_endian(char endian):
 
 
 @cython.profile(False)
-cdef inline int is_native_endian(char endian):
+cdef inline int is_native_endian(char endian) nogil:
     if endian == ENDIAN_NATIVE:
         return 1
 
@@ -155,7 +155,7 @@ cdef inline int is_native_endian(char endian):
 
 
 @cython.profile(False)
-cdef inline int swap_bytes(unsigned char *buffer, Py_ssize_t size):
+cdef inline int swap_bytes(unsigned char *buffer, Py_ssize_t size) nogil:
     cdef unsigned char *buf = <unsigned char *>malloc(size)
 
     if buf == NULL:

--- a/cpyamf/util.pyx
+++ b/cpyamf/util.pyx
@@ -365,7 +365,7 @@ cdef class cBufferedByteStream(object):
         """
         Get raw data from buffer.
         """
-        return PyUnicode_FromStringAndSize(self.buffer, self.length)
+        return self.buffer[:self.length].decode()
 
     cdef Py_ssize_t peek(self, char **buf, Py_ssize_t size) except -1:
         """
@@ -946,7 +946,8 @@ cdef class BufferedByteStream(cBufferedByteStream):
             self.endian = PyString_AsString(value)[0]
 
         def __get__(self):
-            return PyUnicode_FromStringAndSize(&self.endian, 1)
+            return (&self.endian)[:1].decode()
+            # return PyUnicode_FromStringAndSize(&self.endian, 1)
 
     def read(self, size=-1):
         """
@@ -966,8 +967,7 @@ cdef class BufferedByteStream(cBufferedByteStream):
         cdef char *buf = NULL
 
         cBufferedByteStream.read(self, &buf, s)
-
-        return PyUnicode_FromStringAndSize(buf, s)
+        return buf[:s].decode()
 
     def write(self, x, size=-1):
         """
@@ -1006,7 +1006,7 @@ cdef class BufferedByteStream(cBufferedByteStream):
 
         size = cBufferedByteStream.peek(self, &buf, size)
 
-        return PyUnicode_FromStringAndSize(buf, size)
+        return buf[:size].decode()
 
     def write_char(self, x):
         """

--- a/cpyamf/util.pyx
+++ b/cpyamf/util.pyx
@@ -365,7 +365,7 @@ cdef class cBufferedByteStream(object):
         """
         Get raw data from buffer.
         """
-        return PyString_FromStringAndSize(self.buffer, self.length)
+        return PyUnicode_FromStringAndSize(self.buffer, self.length)
 
     cdef Py_ssize_t peek(self, char **buf, Py_ssize_t size) except -1:
         """
@@ -946,7 +946,7 @@ cdef class BufferedByteStream(cBufferedByteStream):
             self.endian = PyString_AsString(value)[0]
 
         def __get__(self):
-            return PyString_FromStringAndSize(&self.endian, 1)
+            return PyUnicode_FromStringAndSize(&self.endian, 1)
 
     def read(self, size=-1):
         """
@@ -967,7 +967,7 @@ cdef class BufferedByteStream(cBufferedByteStream):
 
         cBufferedByteStream.read(self, &buf, s)
 
-        return PyString_FromStringAndSize(buf, s)
+        return PyUnicode_FromStringAndSize(buf, s)
 
     def write(self, x, size=-1):
         """
@@ -1006,7 +1006,7 @@ cdef class BufferedByteStream(cBufferedByteStream):
 
         size = cBufferedByteStream.peek(self, &buf, size)
 
-        return PyString_FromStringAndSize(buf, size)
+        return PyUnicode_FromStringAndSize(buf, size)
 
     def write_char(self, x):
         """

--- a/pyamf/amf3.py
+++ b/pyamf/amf3.py
@@ -1004,7 +1004,7 @@ class Decoder(codec.Decoder):
 
         if class_def.attr_len > 0:
             for i in range(class_def.attr_len):
-                key = self.readBytes()
+                key = self.readString()
 
                 class_def.static_properties.append(key)
 

--- a/pyamf/codec.py
+++ b/pyamf/codec.py
@@ -517,7 +517,7 @@ class Encoder(_Codec):
             return self.writeNumber
         elif t in python.int_types:
             return self.writeNumber
-        elif t in (list, tuple, frozenset):
+        elif t in (list, tuple, set, frozenset):
             return self.writeList
         elif t is types.GeneratorType:  # flake8: noqa
             return self.writeGenerator

--- a/pyamf/remoting/gateway/twisted.py
+++ b/pyamf/remoting/gateway/twisted.py
@@ -227,7 +227,7 @@ class TwistedGateway(gateway.BaseGateway, resource.Resource):
     @type expose_request: C{bool}
     """
 
-    allowedMethods = ('POST',)
+    allowedMethods = (b'POST',)
 
     def __init__(self, *args, **kwargs):
         if 'expose_request' not in kwargs:
@@ -282,7 +282,7 @@ class TwistedGateway(gateway.BaseGateway, resource.Resource):
             if self.debug:
                 body += "\n\nTraceback:\n\n%s" % failure.getTraceback()
 
-            self._finaliseRequest(request, 400, body)
+            self._finaliseRequest(request, 400, body.encode())
 
         request.content.seek(0, 0)
         timezone_offset = self._get_timezone_offset()
@@ -332,7 +332,7 @@ class TwistedGateway(gateway.BaseGateway, resource.Resource):
             if self.debug:
                 body += "\n\nTraceback:\n\n%s" % failure.getTraceback()
 
-            self._finaliseRequest(request, 500, body)
+            self._finaliseRequest(request, 500, body.encode())
 
         timezone_offset = self._get_timezone_offset()
         d = threads.deferToThread(
@@ -399,9 +399,9 @@ class TwistedGateway(gateway.BaseGateway, resource.Resource):
                 "be successfully processed."
 
             if self.debug:
-                body += "\n\nTraceback:\n\n%s" % failure.getTraceback()
+                body += b"\n\nTraceback:\n\n%s" % failure.getTraceback()
 
-            self._finaliseRequest(http_request, 500, body)
+            self._finaliseRequest(http_request, 500, body.encode())
 
         d = defer.DeferredList(dl)
 

--- a/pyamf/tests/gateway/test_django.py
+++ b/pyamf/tests/gateway/test_django.py
@@ -12,6 +12,7 @@ Django gateway tests.
 import unittest
 import sys
 import os
+import types
 
 try:
     from cStringIO import StringIO
@@ -34,6 +35,9 @@ def make_http_request(method, body=''):
     http_request.method = method
 
     version = _django.VERSION[:2]
+
+    if not isinstance(body, bytes):
+        body = body.encode()
 
     if version <= (1, 2):
         http_request.raw_post_data = body
@@ -58,10 +62,8 @@ class DjangoGatewayTestCase(BaseTestCase):
     def setUp(self):
         BaseTestCase.setUp(self)
 
-        import new
-
         self.mod_name = '%s.%s' % (__name__, 'settings')
-        self.settings = sys.modules[self.mod_name] = new.module(self.mod_name)
+        self.settings = sys.modules[self.mod_name] = types.ModuleType(self.mod_name)
 
         self.old_env = os.environ.get('DJANGO_SETTINGS_MODULE', None)
 
@@ -124,16 +126,16 @@ class DjangoGatewayTestCase(BaseTestCase):
 
         request = util.BufferedByteStream()
         request.write(
-            '\x00\x00\x00\x00\x00\x01\x00\x09test.test\x00'
-            '\x02/1\x00\x00\x00\x14\x0a\x00\x00\x00\x01\x08\x00\x00\x00\x00'
-            '\x00\x01\x61\x02\x00\x01\x61\x00\x00\x09'
+            b'\x00\x00\x00\x00\x00\x01\x00\x09test.test\x00'
+            b'\x02/1\x00\x00\x00\x14\x0a\x00\x00\x00\x01\x08\x00\x00\x00\x00'
+            b'\x00\x01\x61\x02\x00\x01\x61\x00\x00\x09'
         )
         request.seek(0, 0)
 
         http_request = make_http_request('POST', request.getvalue())
 
         http_response = gw(http_request)
-        envelope = remoting.decode(http_response.content)
+        envelope = remoting.decode(http_response.content.decode())
 
         message = envelope['/1']
 
@@ -155,8 +157,8 @@ class DjangoGatewayTestCase(BaseTestCase):
 
         request = util.BufferedByteStream()
         request.write(
-            '\x00\x00\x00\x00\x00\x01\x00\x09test.test\x00'
-            '\x02/1\x00\x00\x00\x05\x0a\x00\x00\x00\x00'
+            b'\x00\x00\x00\x00\x00\x01\x00\x09test.test\x00'
+            b'\x02/1\x00\x00\x00\x05\x0a\x00\x00\x00\x00'
         )
         request.seek(0, 0)
 
@@ -194,7 +196,7 @@ class DjangoGatewayTestCase(BaseTestCase):
         self.assertEqual(http_response.status_code, 500)
         self.assertEqual(
             http_response.content,
-            '500 Internal Server Error\n\nAn unexpected error occurred.'
+            b'500 Internal Server Error\n\nAn unexpected error occurred.'
         )
 
     def test_expected_exceptions_decode(self):

--- a/pyamf/tests/remoting/test_remoteobject.py
+++ b/pyamf/tests/remoting/test_remoteobject.py
@@ -125,7 +125,7 @@ class RequestProcessorTestCase(unittest.TestCase):
         self.assertEqual(response.status, remoting.STATUS_ERROR)
         self.assertTrue(isinstance(ack, messaging.ErrorMessage))
         self.assertEqual(ack.faultCode, 'TypeError')
-        self.assertNotEquals(ack.extendedData, None)
+        self.assertNotEqual(ack.extendedData, None)
 
     def test_too_many_args(self):
         def spam(bar):

--- a/pyamf/tests/test_alias.py
+++ b/pyamf/tests/test_alias.py
@@ -210,7 +210,7 @@ class GetEncodableAttributesTestCase(unittest.TestCase):
 
         ret = self.alias.getEncodableAttributes(self.obj)
 
-        self.assertEquals(ret, {'bar': 'bar', 'spam': 'eggs'})
+        self.assertEqual(ret, {'bar': 'bar', 'spam': 'eggs'})
 
 
 class GetDecodableAttributesTestCase(unittest.TestCase):
@@ -385,7 +385,7 @@ class GetDecodableAttributesTestCase(unittest.TestCase):
 
         ret = self.alias.getDecodableAttributes(self.obj, attrs)
 
-        self.assertEquals(ret, {'foo': 'foo', 'spam': 'eggs'})
+        self.assertEqual(ret, {'foo': 'foo', 'spam': 'eggs'})
 
     def test_complex_synonym(self):
         self.alias.synonym_attrs = {'foo_syn': 'bar_syn'}
@@ -409,7 +409,7 @@ class GetDecodableAttributesTestCase(unittest.TestCase):
 
         ret = self.alias.getDecodableAttributes(self.obj, attrs)
 
-        self.assertEquals(ret, {'foo_syn': 'foo', 'spam': 'eggs'})
+        self.assertEqual(ret, {'foo_syn': 'foo', 'spam': 'eggs'})
 
 
 class ApplyAttributesTestCase(unittest.TestCase):
@@ -658,11 +658,11 @@ class SimpleCompliationTestCase(unittest.TestCase):
     def test_synonym_attrs(self):
         x = ClassAlias(Spam, synonym_attrs={'foo': 'bar'}, defer=True)
 
-        self.assertEquals(x.synonym_attrs, {'foo': 'bar'})
+        self.assertEqual(x.synonym_attrs, {'foo': 'bar'})
 
         x.compile()
 
-        self.assertEquals(x.synonym_attrs, {'foo': 'bar'})
+        self.assertEqual(x.synonym_attrs, {'foo': 'bar'})
 
 
 class CompilationInheritanceTestCase(ClassCacheClearingTestCase):

--- a/pyamf/tests/test_alias.py
+++ b/pyamf/tests/test_alias.py
@@ -126,7 +126,7 @@ class ClassAliasTestCase(ClassCacheClearingTestCase):
 
         self.assertEqual(x, A)
         self.assertEqual(x, y)
-        self.assertNotEquals(x, z)
+        self.assertNotEqual(x, z)
 
 
 class GetEncodableAttributesTestCase(unittest.TestCase):
@@ -302,7 +302,7 @@ class GetDecodableAttributesTestCase(unittest.TestCase):
 
         ret = self.alias.getDecodableAttributes(self.obj, attrs)
 
-        self.assertEquals(ret, {
+        self.assertEqual(ret, {
             'foo': 'foo',
             'bar': 'bar',
             'dyn2': 'dyn2',
@@ -981,9 +981,9 @@ class CompilationInheritanceTestCase(ClassCacheClearingTestCase):
         self.assertTrue(b._compiled)
         self.assertTrue(c._compiled)
 
-        self.assertEquals(a.synonym_attrs, {'foo': 'bar', 'bar': 'baz'})
-        self.assertEquals(b.synonym_attrs, {'foo': 'bar', 'bar': 'baz'})
-        self.assertEquals(c.synonym_attrs, {'foo': 'bar', 'bar': 'spam'})
+        self.assertEqual(a.synonym_attrs, {'foo': 'bar', 'bar': 'baz'})
+        self.assertEqual(b.synonym_attrs, {'foo': 'bar', 'bar': 'baz'})
+        self.assertEqual(c.synonym_attrs, {'foo': 'bar', 'bar': 'spam'})
 
 
 class CompilationIntegrationTestCase(unittest.TestCase):

--- a/pyamf/tests/test_amf3.py
+++ b/pyamf/tests/test_amf3.py
@@ -327,7 +327,7 @@ class EncoderTestCase(ClassCacheClearingTestCase, EncoderMixIn):
             y.update({'': 1, 0: 1})
             self.encode(y)
 
-        self.failUnlessRaises(pyamf.EncodeError, x)
+        self.assertRaises(pyamf.EncodeError, x)
 
     def test_object(self):
         try:
@@ -807,7 +807,7 @@ class DecoderTestCase(ClassCacheClearingTestCase, DecoderMixIn):
 
         self.assertEqual(obj.__class__, Spam)
 
-        self.failUnless(hasattr(obj, 'baz'))
+        self.assertTrue(hasattr(obj, 'baz'))
         self.assertEqual(obj.baz, 'hello')
 
     def test_byte_array(self):
@@ -1141,7 +1141,9 @@ class ObjectDecodingTestCase(ClassCacheClearingTestCase, DecoderMixIn):
 
         class_def = self.context.getClass(Spam)
 
-        self.assertEqual(class_def.static_properties, [b'spam'])
+        self.assertTrue("spam" in obj.__dict__)
+
+        self.assertEqual(class_def.static_properties, ['spam'])
 
         self.assertTrue(isinstance(obj, Spam))
         self.assertEqual(obj.__dict__, {'spam': 'eggs'})
@@ -1175,7 +1177,7 @@ class ObjectDecodingTestCase(ClassCacheClearingTestCase, DecoderMixIn):
 
         class_def = self.context.getClass(Spam)
 
-        self.assertEqual(class_def.static_properties, [b'spam'])
+        self.assertEqual(class_def.static_properties, ['spam'])
 
         self.assertTrue(isinstance(obj, Spam))
         self.assertEqual(obj.__dict__, {'spam': 'eggs', 'baz': 'nat'})

--- a/pyamf/tests/test_basic.py
+++ b/pyamf/tests/test_basic.py
@@ -31,7 +31,7 @@ class ASObjectTestCase(unittest.TestCase):
         bag = pyamf.ASObject()
 
         self.assertEqual(bag, {})
-        self.assertNotEquals(bag, {'spam': 'eggs'})
+        self.assertNotEqual(bag, {'spam': 'eggs'})
 
         bag2 = pyamf.ASObject()
 
@@ -645,7 +645,7 @@ class TestAMF0Codecs(unittest.TestCase):
         """
         try:
             from cpyamf import amf0
-        except ImportError:
+        except ImportError as err:
             self.skipTest('amf0 extension not available')
 
         decoder = pyamf.get_decoder(pyamf.AMF0, use_ext=True)

--- a/pyamf/tests/test_basic.py
+++ b/pyamf/tests/test_basic.py
@@ -37,7 +37,7 @@ class ASObjectTestCase(unittest.TestCase):
 
         self.assertEqual(bag2, {})
         self.assertEqual(bag, bag2)
-        self.assertNotEquals(bag, None)
+        self.assertNotEqual(bag, None)
 
     def test_setitem(self):
         bag = pyamf.ASObject()
@@ -74,7 +74,7 @@ class ASObjectTestCase(unittest.TestCase):
     def test_hash(self):
         bag = pyamf.ASObject({'spam': 'eggs'})
 
-        self.assertNotEquals(None, hash(bag))
+        self.assertNotEqual(None, hash(bag))
 
 
 class HelperTestCase(unittest.TestCase):

--- a/pyamf/tests/test_gateway.py
+++ b/pyamf/tests/test_gateway.py
@@ -415,7 +415,7 @@ class BaseGatewayTestCase(unittest.TestCase):
 
         self.assertEqual(response.body.code, 'Service.ResourceNotFound')
         self.assertEqual(response.body.description, 'Unknown service nope')
-        self.assertNotEquals(response.body.details, None)
+        self.assertNotEqual(response.body.details, None)
 
     def test_malformed_credentials_header(self):
         gw = gateway.BaseGateway({'test': TestService})

--- a/pyamf/tests/test_gateway.py
+++ b/pyamf/tests/test_gateway.py
@@ -120,7 +120,7 @@ class ServiceWrapperTestCase(unittest.TestCase):
         z = gateway.ServiceWrapper('bleh')
 
         self.assertEqual(x, y)
-        self.assertNotEquals(y, z)
+        self.assertNotEqual(y, z)
 
     def test_call(self):
         def add(x, y):

--- a/pyamf/tests/test_remoting.py
+++ b/pyamf/tests/test_remoting.py
@@ -75,7 +75,7 @@ class DecoderTestCase(unittest.TestCase):
             b'\x00\x00\x00\x00\x00\x00'
         )
 
-        self.failUnlessRaises(
+        self.assertRaises(
             pyamf.DecodeError,
             remoting.decode,
             b'\x00\x00\x00\x01\x00\x04name\x00\x00\x00\x00\x06\x0a\x00\x00\x00'
@@ -105,7 +105,7 @@ class DecoderTestCase(unittest.TestCase):
         self.assertEqual(y, [])
 
     def test_simple_body(self):
-        self.failUnlessRaises(
+        self.assertRaises(
             IOError,
             remoting.decode,
             '\x00\x00\x00\x00\x00\x01'

--- a/pyamf/tests/test_remoting.py
+++ b/pyamf/tests/test_remoting.py
@@ -141,7 +141,7 @@ class DecoderTestCase(unittest.TestCase):
             b'\x61\x02\x00\x01\x61\x00\x00\x09'
         )
 
-        self.failUnlessRaises(
+        self.assertRaises(
             pyamf.DecodeError,
             remoting.decode,
             b'\x00\x00\x00\x00\x00\x01\x00\x09test.test\x00\x02/1\x00\x00\x00'

--- a/pyamf/tests/test_sol.py
+++ b/pyamf/tests/test_sol.py
@@ -255,7 +255,7 @@ class SOLTestCase(unittest.TestCase):
             self.assertEqual(fp.closed, False)
 
             s.save(fp)
-            self.assertNotEquals(fp.tell(), 0)
+            self.assertNotEqual(fp.tell(), 0)
 
             fp.seek(0)
 

--- a/pyamf/tests/test_sol.py
+++ b/pyamf/tests/test_sol.py
@@ -247,26 +247,26 @@ class SOLTestCase(unittest.TestCase):
 
         self.assertTrue(check_buffer(x.getvalue(), HelperTestCase.contents))
 
-        x = tempfile.mkstemp()[1]
+        tmp_name = tempfile.mkstemp()[1]
 
         try:
-            fp = open(x, 'wb+')
+            with open(tmp_name, 'wb+') as fp:
+                self.assertEqual(fp.closed, False)
 
-            self.assertEqual(fp.closed, False)
+                s.save(fp)
+                self.assertNotEqual(fp.tell(), 0)
 
-            s.save(fp)
-            self.assertNotEqual(fp.tell(), 0)
+                fp.seek(0)
 
-            fp.seek(0)
+                self.assertTrue(check_buffer(fp.read(), HelperTestCase.contents))
+                self.assertEqual(fp.closed, False)
 
-            self.assertTrue(check_buffer(fp.read(), HelperTestCase.contents))
-            self.assertEqual(fp.closed, False)
-
-            self.assertTrue(
-                check_buffer(open(x, 'rb').read(), HelperTestCase.contents)
-            )
+                with open(tmp_name, 'rb') as fp2:
+                    self.assertTrue(
+                        check_buffer(fp2.read(), HelperTestCase.contents)
+                    )
         except:
-            if os.path.isfile(x):
-                os.unlink(x)
+            if os.path.isfile(tmp_name):
+                os.unlink(tmp_name)
 
             raise

--- a/pyamf/tests/test_util.py
+++ b/pyamf/tests/test_util.py
@@ -261,7 +261,7 @@ class StringIOTestCase(unittest.TestCase):
 
 
 class DataTypeMixInTestCase(unittest.TestCase):
-    endians = ('>', '<')  # big, little
+    endians = (b'>', b'<')  # big, little
 
     def _write_endian(self, obj, func, args, expected):
         old_endian = obj.endian
@@ -621,15 +621,15 @@ class DataTypeMixInTestCase(unittest.TestCase):
 
         # now test little endian
         x = util.BufferedByteStream(b'\x00\x00\x00\x00\x00\x00\xf8\xff')
-        x.endian = '<'
+        x.endian = b'<'
         self.assertTrue(isNaN(x.read_double()))
 
         x = util.BufferedByteStream(b'\x00\x00\x00\x00\x00\x00\xf0\xff')
-        x.endian = '<'
+        x.endian = b'<'
         self.assertTrue(isNegInf(x.read_double()))
 
         x = util.BufferedByteStream(b'\x00\x00\x00\x00\x00\x00\xf0\x7f')
-        x.endian = '<'
+        x.endian = b'<'
         self.assertTrue(isPosInf(x.read_double()))
 
     def test_write_infinites(self):

--- a/pyamf/util/pure.py
+++ b/pyamf/util/pure.py
@@ -188,7 +188,15 @@ class DataTypeMixIn(object):
     #: Big endian
     ENDIAN_BIG = ">"
 
-    endian = ENDIAN_NETWORK
+    __endian = ENDIAN_NETWORK
+
+    @property
+    def endian(self):
+        return self.__endian
+
+    @endian.setter
+    def endian(self, value):
+        self.__endian = value.decode('utf-8') if isinstance(value, bytes) else value
 
     def _read(self, length):
         """

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ Natural Language :: English
 Operating System :: OS Independent
 Programming Language :: C
 Programming Language :: Python
+Programming Language :: Cython
 Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7

--- a/setupinfo.py
+++ b/setupinfo.py
@@ -26,8 +26,7 @@ from distutils.core import Distribution
 
 _version = None
 
-jython = sys.platform.startswith('java')
-can_compile_extensions = not jython
+can_compile_extensions = sys.platform.python_implementation() == "CPython"
 
 
 class MyDistribution(Distribution):

--- a/setupinfo.py
+++ b/setupinfo.py
@@ -264,8 +264,6 @@ def get_extensions():
 
     extensions = []
 
-    # Hide Cython extension
-    """
     for p in recursive_glob('.', '*.pyx'):
         mod_name = os.path.splitext(p)[0].replace(os.path.sep, '.')
 
@@ -273,7 +271,6 @@ def get_extensions():
 
         if e:
             extensions.append(e)
-    """
 
     return extensions
 

--- a/setupinfo.py
+++ b/setupinfo.py
@@ -134,12 +134,11 @@ def get_version():
 
 def get_extras_require():
     return {
-        'wsgi': ['wsgiref'],
-        'twisted': ['Twisted>=2.5.0'],
+        'twisted': ['Twisted>=16.0.0'],
         'django': ['Django>=0.96'],
         'sqlalchemy': ['SQLAlchemy>=0.4'],
         'elixir': ['Elixir>=0.7.1'],
-        'lxml': ['lxml>=2.2'],
+        'lxml': ['lxml>=4.4.0'],
         'six': ['six>=1.10.0']
     }
 
@@ -177,7 +176,7 @@ def get_install_requirements():
 
     if 'dev' in get_version():
         if can_compile_extensions:
-            install_requires.extend(['Cython>=0.13'])
+            install_requires.extend(['Cython>=0.28'])
 
     return install_requires
 

--- a/setupinfo.py
+++ b/setupinfo.py
@@ -175,9 +175,6 @@ def get_install_requirements():
     """
     install_requires = ['defusedxml']
 
-    if sys.version_info < (2, 5):
-        install_requires.extend(["elementtree>=1.2.6", "uuid>=1.30"])
-
     if 'dev' in get_version():
         if can_compile_extensions:
             install_requires.extend(['Cython>=0.13'])
@@ -190,9 +187,6 @@ def get_test_requirements():
     Returns a list of required packages to run the test suite.
     """
     tests_require = []
-
-    if sys.version_info < (2, 7):
-        tests_require.extend(['unittest2'])
 
     return tests_require
 
@@ -250,6 +244,7 @@ def get_extensions():
     Return a list of Extension instances that can be compiled.
     """
     if not can_compile_extensions:
+        # due to changes in pip these prints have no effect
         print(80 * '*')
         print('WARNING:')
         print(

--- a/setupinfo.py
+++ b/setupinfo.py
@@ -5,9 +5,10 @@
 Meta data and helper functions for setup
 """
 
-import sys
-import os.path
 import fnmatch
+import os.path
+import platform
+import sys
 
 try:
     from Cython.Distutils import build_ext
@@ -26,7 +27,7 @@ from distutils.core import Distribution
 
 _version = None
 
-can_compile_extensions = sys.platform.python_implementation() == "CPython"
+can_compile_extensions = platform.python_implementation() == "CPython"
 
 
 class MyDistribution(Distribution):


### PR DESCRIPTION
binaries are tested on py3.7 and py3.9. All seems to be ok.