### PR TITLE
Remove python 3.10 SyntaxWarning

### DIFF
--- a/pyamf/util/__init__.py
+++ b/pyamf/util/__init__.py
@@ -201,7 +201,7 @@ def get_module(mod_name):
     if isinstance(mod_name, bytes):
         mod_name = mod_name.decode()
 
-    if mod_name is '':
+    if mod_name == '':
         raise ImportError('Unable to import empty module')
 
     mod = __import__(mod_name)


### PR DESCRIPTION
If I run with python 3.10 I get the following warning

/venv/lib/python3.10/site-packages/pyamf/util/__init__.py:204: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if mod_name is '':

This PR should remove it